### PR TITLE
Update darklua configurations to use `.luaurc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- update darklua configurations to use `.luaurc` instead of providing custom aliases ([#44](https://github.com/seaofvoices/generator-luau/pull/44))
 - update luau-lsp VSCode settings and remove `.luau-analyze.json` file since it is not needed anymore ([#43](https://github.com/seaofvoices/generator-luau/pull/43))
 - change default file extension to `.luau` ([#41](https://github.com/seaofvoices/generator-luau/pull/41))
 - fix Roblox build script when using npm as the package manager ([#40](https://github.com/seaofvoices/generator-luau/pull/40))

--- a/src/app/darkluaConfig.js
+++ b/src/app/darkluaConfig.js
@@ -33,12 +33,7 @@ export const buildDarkluaConfig = (options) => ({
     'remove_spaces',
     {
       rule: 'convert_require',
-      current: {
-        name: 'path',
-        sources: {
-          '@pkg': 'node_modules/.luau-aliases',
-        },
-      },
+      current: 'path',
       target: {
         name: 'roblox',
         rojo_sourcemap: 'sourcemap.json',
@@ -51,12 +46,7 @@ export const buildDarkluaConfig = (options) => ({
 
 export const buildBundleDarkluaConfig = (options) => ({
   bundle: {
-    require_mode: {
-      name: 'path',
-      sources: {
-        '@pkg': 'node_modules/.luau-aliases',
-      },
-    },
+    require_mode: 'path',
   },
   rules: [
     'remove_types',


### PR DESCRIPTION
Darklua does not need custom aliases definition anymore (since 0.16.0)

- [x] add entry to the changelog
