### PR TITLE
Improve npmignore template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- update npmignore template to exclude root level Roblox files, Rojo configs and sourcemaps and type Luau definition files ([#46](https://github.com/seaofvoices/generator-luau/pull/46))
+
 ## 0.1.6
 
 - update darklua configurations to use `.luaurc` instead of providing custom aliases ([#44](https://github.com/seaofvoices/generator-luau/pull/44))

--- a/src/package/templates/npm_ignore
+++ b/src/package/templates/npm_ignore
@@ -25,9 +25,13 @@
 jest.config.lua
 jest.config.luau
 
-**/*.rbxl
-**/*.rbxlx
-**/*.rbxl.lock
-**/*.rbxlx.lock
-**/*.rbxm
-**/*.rbxmx
+/globalTypes.d.lua
+sourcemap.json
+*.project.json
+
+*.rbxl
+*.rbxlx
+*.rbxl.lock
+*.rbxlx.lock
+*.rbxm
+*.rbxmx


### PR DESCRIPTION
Update npmignore with patterns to catch root level Roblox related files, type definition files, rojo configuration files and generated rojo sourcemaps.

- [x] add entry to the changelog
